### PR TITLE
Add vendor URL to font info

### DIFF
--- a/.github/workflows/regional_fonts.yml
+++ b/.github/workflows/regional_fonts.yml
@@ -24,7 +24,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checkout pull request HEAD commit instead of merge commit
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Python version
         uses: actions/setup-python@v2

--- a/.github/workflows/temporal_fonts.yml
+++ b/.github/workflows/temporal_fonts.yml
@@ -24,7 +24,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checkout pull request HEAD commit instead of merge commit
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Python version
         uses: actions/setup-python@v2

--- a/helper.sh
+++ b/helper.sh
@@ -161,7 +161,7 @@ create_cjk_unihan_core() {
     cd "$OLDPWD"
 
     go_build "$output_font" \
-             "$subset_ttf" NotoSans-Regular.ttf NotoMusic-Regular.ttf \
+             NotoSans-Regular.ttf "$subset_ttf" NotoMusic-Regular.ttf \
              NotoSansSymbols-Regular.ttf NotoSansSymbols2-Regular.ttf
 }
 

--- a/rename_font.py
+++ b/rename_font.py
@@ -3,23 +3,28 @@
 """Edit metadata about font names"""
 
 import sys
+from subprocess import check_output
 from fontTools.ttLib import TTFont
 
 fontname = sys.argv[1]
 name_with_spaces = sys.argv[2]
 name_without_spaces = sys.argv[3]
 
+git_hash = lambda: check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+
 font = TTFont(fontname)
 
 # https://docs.microsoft.com/en-gb/typography/opentype/spec/name
 for record in font['name'].names:
-    if record.nameID == 1:
+    if record.nameID == 1: # font family name
         family = record.toStr()
-    elif record.nameID == 2:
+    elif record.nameID == 2: # font style
         subfamily = record.toStr()
         new_postscript_name = name_without_spaces + "-" + subfamily
-    elif record.nameID == 6:
+    elif record.nameID == 6: # postscript name
         postscript_name = record.toStr()
+    elif record.nameID == 10: # description
+        description = record.toStr()
 
 for record in font['name'].names:
     encoding = record.getEncoding()
@@ -34,6 +39,13 @@ for record in font['name'].names:
         record.string = new_name.encode(encoding)
     elif record.nameID == 6: # postscript name
         record.string = new_postscript_name.encode(encoding)
+    elif record.nameID == 10: # description
+        record.string = (description +
+                         " The Go Noto Universal project merged many upstream Noto Fonts to produce this font."
+                        ).encode(encoding)
+    elif record.nameID == 11: # vendor URL
+        record.string = ("https://github.com/satbyy/go-noto-universal/tree/" +
+                         git_hash()).encode(encoding)
 
 font.save(fontname)
 font.close()


### PR DESCRIPTION
Include git hash in the URL so that it is easier to trace the commit
where the font was built from.