### PR TITLE
Add black-and-white Noto Emoji

### DIFF
--- a/categories.sh
+++ b/categories.sh
@@ -190,6 +190,7 @@ GoNotoCurrent=(
     "NotoSansSymbols2-Regular.ttf"
     "NotoSansMath-Regular.ttf"
     "NotoMusic-Regular.ttf"
+    "NotoEmoji-Regular.ttf"
 )
 
 GoNotoAfricaMiddleEast=(

--- a/helper.sh
+++ b/helper.sh
@@ -72,6 +72,25 @@ drop_vertical_tables() {
     cd "$OLDPWD"
 }
 
+# download black-and-white Noto Emoji (not NotoColor)
+fetch_noto_emoji() {
+    local output_font=NotoEmoji-Regular.ttf
+    local url="https://fonts.google.com/download?family=Noto%20Emoji"
+    local zipfile=$(basename "$url")
+
+    if [[ -e "$output_font" ]]; then
+        echo "Not overwriting existing font $output_font."
+        return
+    fi
+
+    cd cache/
+    download_url "$url"
+    python3 -m zipfile -e "$zipfile" .
+    mv static/"$output_font" .
+    rm -rf "$zipfile" static/
+    cd "$OLDPWD"
+}
+
 # create tibetan subset so that GSUB is not overflow'ed.
 create_tibetan_subset() {
     local input_font=NotoSerifTibetan-Regular.ttf

--- a/temporal_fonts.sh
+++ b/temporal_fonts.sh
@@ -13,6 +13,7 @@ source categories.sh
 mkdir -p cache/
 
 # GoNotoCurrent.ttf
+fetch_noto_emoji
 create_cjk_subset
 create_japanese_kana_subset
 create_korean_hangul_subset


### PR DESCRIPTION
Currently failing because of mismatched metrics (1000 for other fonts vs 2048 for NotoEmoji). This must be fixed upstream.