### PR TITLE
Don't use fontools 4.41.0

### DIFF
--- a/regional_fonts.sh
+++ b/regional_fonts.sh
@@ -3,7 +3,7 @@ set -e
 
 [[ -z "$VIRTUAL_ENV" ]] && echo "Refusing to run outside of venv. See README.md." && exit 1
 
-python3 -m pip install 'fonttools >= 4.28.5'
+python3 -m pip install 'fonttools < 4.41.0' # perf regression
 
 # import functions and globals
 source url.sh

--- a/temporal_fonts.sh
+++ b/temporal_fonts.sh
@@ -3,7 +3,7 @@ set -e
 
 [[ -z "$VIRTUAL_ENV" ]] && echo "Refusing to run outside of venv. See README.md." && exit 100
 
-python3 -m pip install 'fonttools >= 4.28.5'
+python3 -m pip install 'fonttools < 4.41.0' # perf regression
 
 # import functions and globals
 source url.sh


### PR DESCRIPTION
This version causes builds to time out.

Fixes: https://github.com/satbyy/go-noto-universal/issues/59