### PR TITLE
Revert "Don't use fontools 4.41.0"

### DIFF
--- a/regional_fonts.sh
+++ b/regional_fonts.sh
@@ -3,7 +3,7 @@ set -e
 
 [[ -z "$VIRTUAL_ENV" ]] && echo "Refusing to run outside of venv. See README.md." && exit 1
 
-python3 -m pip install 'fonttools < 4.41.0' # perf regression
+python3 -m pip install 'fonttools >= 4.41.1'
 
 # import functions and globals
 source url.sh

--- a/temporal_fonts.sh
+++ b/temporal_fonts.sh
@@ -3,7 +3,7 @@ set -e
 
 [[ -z "$VIRTUAL_ENV" ]] && echo "Refusing to run outside of venv. See README.md." && exit 100
 
-python3 -m pip install 'fonttools < 4.41.0' # perf regression
+python3 -m pip install 'fonttools >= 4.41.1'
 
 # import functions and globals
 source url.sh


### PR DESCRIPTION
This reverts commit 2ac77bdae0dd9484566a0a2fc10806e0c851e1fd.

Performace regression (in 4.41.0) has been fixed in 4.41.1 onwards.

See https://github.com/fonttools/fonttools/releases/tag/4.41.1 